### PR TITLE
VALG-185 - Dynamic assignment of secretary role

### DIFF
--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_volunteers/valghalla_volunteers.info
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_volunteers/valghalla_volunteers.info
@@ -20,6 +20,7 @@ dependencies[] = text
 dependencies[] = valghalla_election
 dependencies[] = valghalla_mail
 dependencies[] = valghalla_polling_station
+dependencies[] = valhalla_settings
 stylesheets[all][] = valhalla_volunteers.css
 configure = admin/config/valhalla/volunteers
 features[features_api][] = api:2

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_volunteers/valghalla_volunteers.module
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_volunteers/valghalla_volunteers.module
@@ -864,10 +864,12 @@ function valghalla_volunteers_add_sub_secretary_form_validate($form, array &$for
 function valghalla_volunteers_add_sub_secretary_form_submit($form, array &$form_state) {
   form_state_values_clean($form_state);
 
+  $secretary_of_party = variable_get('valhalla_settings_party_secretary_role_id', 4);
+
   // setup defaults
   $form_state['values']['pass'] = user_password();
   $form_state['values']['status'] = 1;
-  $form_state['values']['roles'] = array(4 => 4);
+  $form_state['values']['roles'] = array($secretary_of_party => $secretary_of_party);
   $form_state['values']['init'] = $form_state['values']['mail'];
 
   $account = $form['#user'];

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valhalla_settings/valhalla_settings.info
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valhalla_settings/valhalla_settings.info
@@ -9,4 +9,6 @@ name = valhalla_settings
 description =  Holds functionality to "lock" the "valgsted" content type. 
 
 package = Valghalla
+project = Valghalla
 core = 7.x
+configure = admin/valghalla/settings

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valhalla_settings/valhalla_settings.install
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valhalla_settings/valhalla_settings.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Try to assign the 'Partisekretær' role automatically in settings.
+ */
+function valhalla_settings_update_7000() {
+  $role = user_role_load_by_name('Partisekretær');
+
+  if ($role) {
+    variable_set('valhalla_settings_party_secretary_role_id', $role->rid);
+  }
+  else {
+    drupal_set_message(t('You MUST manually specify the "Partisekretær" role in settings admin/valghalla/settings'), 'warning');
+  }
+}

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valhalla_settings/valhalla_settings.module
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valhalla_settings/valhalla_settings.module
@@ -37,6 +37,15 @@ function valhalla_admin_settings_form($form, &$form_state) {
     '#default_value' => variable_get('valhalla_settings_hide_address_fields', 0),
   );
 
+  // Chose which role is the 'Partisekretær'
+  $form['valhalla_settings_party_secretary_role_id'] = array(
+    '#title' => 'Vælg hvilken rolle, som er "Partisekretær"',
+    '#type' => 'select',
+    '#options' => user_roles(TRUE),
+    '#default_value' => variable_get('valhalla_settings_party_secretary_role_id'),
+    '#required' => TRUE,
+  );
+
   return system_settings_form($form);
 }
 


### PR DESCRIPTION
Update hook automatically assigns Partisekretær role if possible
Dynamically assigning the role of Partisekretær to new sub-secretaries instead of hardcoding